### PR TITLE
added Community-Producer and Community-User as Maven Modules

### DIFF
--- a/Community-Producer/pom.xml
+++ b/Community-Producer/pom.xml
@@ -3,10 +3,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.disys</groupId>
+
+  <parent>
+    <groupId>com.disys</groupId>
+    <artifactId>DISYS_GroupE</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
   <artifactId>Community-Producer</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <name>Community-Producer</name>
 
   <properties>
     <maven.compiler.source>17</maven.compiler.source>

--- a/Community-User/pom.xml
+++ b/Community-User/pom.xml
@@ -3,10 +3,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.disys</groupId>
+
+  <parent>
+    <groupId>com.disys</groupId>
+    <artifactId>DISYS_GroupE</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
   <artifactId>Community-User</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <name>Community-User</name>
 
   <properties>
     <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
     <module>API</module>
     <module>UsageService</module>
     <module>CurrentPercentageService</module>
+    <module>Community-Producer</module>
+    <module>Community-User</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
added both Community-producer and Community-User as maven Modules.
Now they are recogniste as seperate Modules by the project and can be started.

I only changed the pom.xml files in both Modules and in the Project.